### PR TITLE
add 'led-matrix' feature to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ measurements = "0.10.2"
 i2cdev = "0.4.0"
 byteorder = "1.0"
 libc = { version = "0.2", optional = true }
+sensehat-screen = { version = "0.1", optional = true }
 
 [build-dependencies]
 gcc = "0.3"
@@ -23,6 +24,7 @@ gcc = "0.3"
 # packages, but they are strictly optional.
 default = ["rtimu"]
 rtimu = [ "libc" ]
+led-matrix = ["sensehat-screen"]
 
 [package.metadata.docs.rs]
 features = [ ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,9 @@ extern crate measurements;
 #[cfg(feature = "rtimu")]
 extern crate libc;
 
+#[cfg(feature = "led-matrix")]
+extern crate sensehat_screen;
+
 mod rh;
 mod hts221;
 mod lps25h;


### PR DESCRIPTION
Use the 'sensehat-screen' crate for LED Matrix support.