### PR TITLE
Implement Error and Display for SenseHatError

### DIFF
--- a/src/lsm9ds1.rs
+++ b/src/lsm9ds1.rs
@@ -9,6 +9,8 @@
 //! a C wrapper of the `RTIMULib` C++ API. We then call that unsafe C wrapper
 //! here, ensuring that any memory allocations were undone on drop.
 
+use std::fmt::Display;
+
 use super::{Angle, ImuData, Orientation, Vector3D};
 use libc;
 
@@ -62,6 +64,16 @@ struct CVector3D {
 pub enum Error {
     RTIMULibError,
 }
+
+impl Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::RTIMULibError => write!(f, "RTIMULib error"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
 
 pub(crate) struct Lsm9ds1<'a> {
     rtimulib_ref: &'a mut RTIMULibContext,

--- a/src/lsm9ds1_dummy.rs
+++ b/src/lsm9ds1_dummy.rs
@@ -3,11 +3,19 @@
 //! This is just a placeholder so the the docs build without RTIMULib.
 
 use super::ImuData;
-use std::marker::PhantomData;
+use std::{fmt::Display, marker::PhantomData};
 
 #[derive(Debug)]
 pub enum Error {
     RTIMULibError,
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::RTIMULibError => write!(f, "RTIMULib Error"),
+        }
+    }
 }
 
 pub(crate) struct Lsm9ds1<'a> {


### PR DESCRIPTION
Implements `std::error::Error` for `SenseHatError` to bring it in line with Rust's error handling ecosystem.

This is needed, for example, for using the `?` notation as well as crates like [anyhow](https://docs.rs/anyhow/latest/anyhow/) and [thiserror](https://docs.rs/thiserror/latest/thiserror/) which make working with errors much more convenient.

Please let me know what you think of the changes.